### PR TITLE
Fixing removeCustomAttributeChoice route

### DIFF
--- a/tdapi.js
+++ b/tdapi.js
@@ -1358,7 +1358,7 @@ TDAPI.prototype.removeCustomAttributeChoice = function (id, choiceId) {
     .then(bearerToken => {
       return request({
         method: 'DELETE',
-        url: `${this.baseUrl}/attributes/${id}/${choiceId}`,
+        url: `${this.baseUrl}/attributes/${id}/choices/${choiceId}`,
         auth: { bearer: bearerToken },
         json: true
       });


### PR DESCRIPTION
Url was missing a '/choices/'. Request returned 404 before this change.